### PR TITLE
Corrected the behavior of the ``truncate*`` methods to match Django.

### DIFF
--- a/lib/filters/truncatechars.js
+++ b/lib/filters/truncatechars.js
@@ -3,5 +3,6 @@ exports.truncatechars = function(callback, input, n) {
       num = parseInt(n, 10);
 
   if(isNaN(num)) return callback(null, input);
+  if(input.length <= num) return callback(null, input);
   callback(null, input.slice(0, num)+'...');
 };

--- a/lib/filters/truncatewords.js
+++ b/lib/filters/truncatewords.js
@@ -3,5 +3,7 @@ exports.truncatewords = function(callback, input, n) {
       num = parseInt(n, 10);
 
   if(isNaN(num)) return callback(null, input);
-  callback(null, input.split(/\s+/).slice(0, num).join(' ')+'...');
+  var words = input.split(/\s+/);
+  if(words.length <= num) return callback(null, input);
+  callback(null, words.slice(0, num).join(' ')+'...');
 };

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -934,7 +934,7 @@ exports.TestOfTimesince = platoon.unit({},
 
     tpl.render({t:t, n:t}, assert.async(function(err, data) {
       assert.equal(data, '0 minutes')
-    })) 
+    }))
   }
 )
 
@@ -1001,7 +1001,7 @@ exports.TestOfTruncateChars = platoon.unit({},
           context = {input:input};
 
       tpl.render(context, assert.async(function(err, data) {
-        assert.equal(data, 'This is a collection of words....');
+        assert.equal(data, 'This is a collection of words.');
       }));
     },
     function(assert) {
@@ -1040,7 +1040,7 @@ exports.TestOfTruncateWords = platoon.unit({},
           context = {input:input};
 
       tpl.render(context, assert.async(function(err, data) {
-        assert.equal(data, 'This is a collection of words....');
+        assert.equal(data, 'This is a collection of words.');
       }));
     },
     function(assert) {


### PR DESCRIPTION
Turns out Django doesn't always put the ellipsis on the end. :sparkles: :+1: :sparkles:
