### PR TITLE
Fix pluralize defaulting to 's'

### DIFF
--- a/lib/filters/pluralize.js
+++ b/lib/filters/pluralize.js
@@ -1,9 +1,5 @@
 module.exports = function(input, plural) {
-  if(plural && typeof plural === 'string') {
-    plural = plural.split(',')
-  } else {
-    plural = 's'
-  }
+  plural = (typeof plural === 'string' ? plural : 's').split(',')
 
   var val = Number(input)
     , suffix

--- a/lib/filters/pluralize.js
+++ b/lib/filters/pluralize.js
@@ -1,5 +1,9 @@
 module.exports = function(input, plural) {
-  plural = (plural || 's').split(',')
+  if(plural && typeof plural === 'string') {
+    plural = plural.split(',')
+  } else {
+    plural = 's'
+  }
 
   var val = Number(input)
     , suffix


### PR DESCRIPTION
the last parameter is always a callback, so plural will not be falsy when no string is passed
