### PR TITLE
Fixes the |urlize filters to work with GET params.

### DIFF
--- a/lib/filters/urlize.js
+++ b/lib/filters/urlize.js
@@ -2,7 +2,7 @@ var safe = require('./safe')
 
 module.exports = function(input) {
   var str = input.toString()
-  return safe(str.replace(/(((http(s)?:\/\/)|(mailto:))([\w\d\-\.:@\/])+)/g, function() {
-    return '<a href="'+arguments[0]+'">'+arguments[0]+'</a>'; 
+  return safe(str.replace(/(((http(s)?:\/\/)|(mailto:))([\w\d\-\.:@\/?&=])+)/g, function() {
+    return '<a href="'+arguments[0]+'">'+arguments[0]+'</a>';
   }))
 }

--- a/lib/filters/urlizetrunc.js
+++ b/lib/filters/urlizetrunc.js
@@ -3,8 +3,8 @@ var safe = require('./safe')
 module.exports = function(input, len) {
   var str = input.toString()
   len = parseInt(len, 10) || 1000
-  return safe(str.replace(/(((http(s)?:\/\/)|(mailto:))([\w\d\-\.:@])+)/g, function() {
+  return safe(str.replace(/(((http(s)?:\/\/)|(mailto:))([\w\d\-\.:@?&=])+)/g, function() {
     var ltr = arguments[0].length > len ? arguments[0].slice(0, len) + '...' : arguments[0];
-    return '<a href="'+arguments[0]+'">'+ltr+'</a>'; 
+    return '<a href="'+arguments[0]+'">'+ltr+'</a>';
   }))
 }

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -1100,10 +1100,10 @@ test("Test that urlencode encodes all appropriate characters by using the built-
 )
 
 test("Test that urlize will turn urls of the form http://whatever.com/whatever, https://whatever.org/whatever into links.", mocktimeout(function(assert) {
-      
-      var links = ['https://google.com/', 'http://neversaw.us/media/blah.png'],
-          para = ['hey there i love ', links[0], ' and(',links[1],')'].join(''),
-          result = 'hey there i love <a href="'+links[0]+'">'+links[0]+'</a> and(<a href="'+links[1]+'">'+links[1]+'</a>)';
+
+      var links = ['https://google.com/', 'http://neversaw.us/media/blah.png', 'http://example.com/?some=params&are=here'],
+          para = ['hey there i love ', links[0], ' and(',links[1],')', ' and paramed ', links[2]].join(''),
+          result = 'hey there i love <a href="'+links[0]+'">'+links[0]+'</a> and(<a href="'+links[1]+'">'+links[1]+'</a>) and paramed <a href="'+links[2]+'">'+links[2]+'</a>';
 
       var tpl = new plate.Template('{{ para|urlize }}');
 


### PR DESCRIPTION
Adding ?&= to the valid URL chars so urls with GET params don't get split up.
