### PR TITLE
New-style with-tag ({% with a=b x=y %})

### DIFF
--- a/lib/tags/with.js
+++ b/lib/tags/with.js
@@ -2,44 +2,98 @@ module.exports = WithNode
 
 var Promise = require('../promise')
 
-function WithNode(with_var, as_var, nodes) {
-  this.with_var = with_var
-  this.as_var = as_var
+function WithNode(nodes, extra_context) {
   this.nodes = nodes
+  this.extra_context = extra_context || {}
 }
 
 var cons = WithNode
   , proto = cons.prototype
+  , kwarg_re = /(?:(\w+)=)?(.+)/
+
+function token_kwargs(bits, parser) {
+  var match
+    , kwarg_format
+    , kwargs
+    , key
+    , value
+
+  if(!bits.length)
+    return {}
+  match = kwarg_re.exec(bits[0])
+  kwarg_format = match && match[1]
+  if(!kwarg_format)
+    if(bits.length < 3 || bits[1] != 'as')
+      return {}
+
+  kwargs = {}
+  while(bits.length) {
+    if(kwarg_format) {
+      match = kwarg_re.exec(bits[0])
+      if(!match || !match[1]){
+        return kwargs
+      }
+      key = match[1]
+      value = match[2]
+      bits.shift()
+    } else {
+      if(bits.length < 3 || bits[1] != 'as') {
+        return kwargs
+      }
+      key = bits[2]
+      value = bits[0]
+      bits.splice(0, 3)
+    }
+    kwargs[key] = parser.compile(value)
+    if(bits.length && !kwarg_format) {
+      if(bits[0] != 'and') {
+        return kwargs
+      }
+      bits.shift()
+    }
+  }
+  return kwargs
+}
 
 cons.parse = function(contents, parser) {
   var bits = contents.split(/\s+/g)
-    , withvar = parser.compile(bits[1])
-    , asvar = bits[3]
     , nodelist = parser.parse(['endwith'])
+    , has_context_vars = false
+    , remaining_bits
+    , extra_context
+
+
+  remaining_bits = bits.slice(1)
+  extra_context = token_kwargs(remaining_bits, parser)
+
+  for(var context_var in extra_context)
+    if(extra_context.hasOwnProperty(context_var)) {
+      has_context_vars = true
+      break
+    }
+
+  if (!has_context_vars)
+      throw new Error('"'+bits[0]+'" expected at least one variable assignment')
+  if (remaining_bits.length)
+      throw new Error('"'+bits[0]+'" received an invalid token: "'+remaining_bits[0]+'"')
 
   parser.tokens.shift()
-  return new cons(withvar, asvar, nodelist)
+  return new cons(nodelist, extra_context)
 }
 
 proto.render = function(context, value) {
-  var self = this 
+  var self = this
     , result
     , promise
 
-  value = arguments.length === 2 ? value : self.with_var.resolve(context)
-
-  if(value && value.constructor === Promise) {
-    promise = new Promise
-
-    value.once('done', function(data) {
-      promise.resolve(self.render(context, data))
-    })
-
-    return promise
-  }
-
   context = context.copy()
-  context[self.as_var] = value
+
+  for(var key in self.extra_context) {
+    if(self.extra_context.hasOwnProperty(key)) {
+      value = self.extra_context[key].resolve(context)
+      context[key] = value
+    }
+  }
 
   result = self.nodes.render(context)
 

--- a/lib/tags/with.js
+++ b/lib/tags/with.js
@@ -18,19 +18,22 @@ function token_kwargs(bits, parser) {
     , key
     , value
 
-  if(!bits.length)
+  if(!bits.length) {
     return {}
+  }
   match = kwarg_re.exec(bits[0])
   kwarg_format = match && match[1]
-  if(!kwarg_format)
-    if(bits.length < 3 || bits[1] != 'as')
+  if(!kwarg_format) {
+    if(bits.length < 3 || bits[1] !== 'as') {
       return {}
+    }
+  }
 
   kwargs = {}
   while(bits.length) {
     if(kwarg_format) {
       match = kwarg_re.exec(bits[0])
-      if(!match || !match[1]){
+      if(!match || !match[1]) {
         return kwargs
       }
       key = match[1]
@@ -66,16 +69,19 @@ cons.parse = function(contents, parser) {
   remaining_bits = bits.slice(1)
   extra_context = token_kwargs(remaining_bits, parser)
 
-  for(var context_var in extra_context)
+  for(var context_var in extra_context) {
     if(extra_context.hasOwnProperty(context_var)) {
       has_context_vars = true
       break
     }
+  }
 
-  if (!has_context_vars)
-      throw new Error('"'+bits[0]+'" expected at least one variable assignment')
-  if (remaining_bits.length)
-      throw new Error('"'+bits[0]+'" received an invalid token: "'+remaining_bits[0]+'"')
+  if (!has_context_vars) {
+    throw new Error('"'+bits[0]+'" expected at least one variable assignment')
+  }
+  if (remaining_bits.length) {
+    throw new Error('"'+bits[0]+'" received an invalid token: "'+remaining_bits[0]+'"')
+  }
 
   parser.tokens.shift()
   return new cons(nodelist, extra_context)
@@ -105,15 +111,15 @@ proto.render = function(context) {
       if(value && value.constructor === Promise) {
         promises++
         value.once('done', promise_resolved(key))
-      }
-      else {
+      } else {
         context[key] = value
       }
     }
   }
 
-  if (promises)
+  if(promises) {
     return promise
+  }
 
   return self.nodes.render(context)
 }

--- a/lib/tags/with.js
+++ b/lib/tags/with.js
@@ -81,21 +81,41 @@ cons.parse = function(contents, parser) {
   return new cons(nodelist, extra_context)
 }
 
-proto.render = function(context, value) {
+proto.render = function(context) {
   var self = this
     , result
-    , promise
+    , promise = new Promise
+    , promises = 0
 
   context = context.copy()
+
+  function promise_resolved(key) {
+    return function(data) {
+      context[key] = data;
+      if (--promises === 0) {
+        promise.resolve(self.nodes.render(context))
+      }
+    }
+  }
 
   for(var key in self.extra_context) {
     if(self.extra_context.hasOwnProperty(key)) {
       value = self.extra_context[key].resolve(context)
-      context[key] = value
+
+      if(value && value.constructor === Promise) {
+        promises++
+        value.once('done', promise_resolved(key))
+      }
+      else {
+        context[key] = value
+      }
     }
   }
 
-  result = self.nodes.render(context)
+  if (promises)
+    return promise
+  else
+    result = self.nodes.render(context)
 
   return result
 }

--- a/lib/tags/with.js
+++ b/lib/tags/with.js
@@ -86,6 +86,7 @@ proto.render = function(context) {
     , result
     , promise = new Promise
     , promises = 0
+    , value
 
   context = context.copy()
 

--- a/lib/tags/with.js
+++ b/lib/tags/with.js
@@ -83,7 +83,6 @@ cons.parse = function(contents, parser) {
 
 proto.render = function(context) {
   var self = this
-    , result
     , promise = new Promise
     , promises = 0
     , value
@@ -115,8 +114,6 @@ proto.render = function(context) {
 
   if (promises)
     return promise
-  else
-    result = self.nodes.render(context)
 
-  return result
+  return self.nodes.render(context)
 }

--- a/tests/tags.js
+++ b/tests/tags.js
@@ -239,8 +239,8 @@ test("Test that for can reverse the contents of an array prior to iteration", mo
     })
 )
 
-test("Test that the with is enabled by default", mocktimeout(function(assert) {
-        
+test("Test that old-style with is enabled by default", mocktimeout(function(assert) {
+
         assert.doesNotThrow(function() {
             var tpl = new plate.Template("{% with x as y %}\n\n{% endwith %}");
             tpl.render({}, function(){});
@@ -248,8 +248,8 @@ test("Test that the with is enabled by default", mocktimeout(function(assert) {
     })
 )
 
-test("Test that with adds the variable into context", mocktimeout(function(assert) {
-        
+test("Test that old-style with adds the variable into context", mocktimeout(function(assert) {
+
         var context = {
             'value':~~(Math.random()*10)
         };
@@ -261,8 +261,8 @@ test("Test that with adds the variable into context", mocktimeout(function(asser
     })
 )
 
-test("Test that with does not leak context variables", mocktimeout(function(assert) {
-        
+test("Test that old-style with does not leak context variables", mocktimeout(function(assert) {
+
         var context = {
             'value':'hi'+~~(Math.random()*10),
             'othervalue':~~(Math.random()*10)+'yeah'
@@ -275,9 +275,69 @@ test("Test that with does not leak context variables", mocktimeout(function(asse
     })
 )
 
-test("Test that an unclosed with statement throws an error", mocktimeout(function(assert) {
-        
+test("Test that an unclosed old-style with statement throws an error", mocktimeout(function(assert) {
+
         var tpl = new plate.Template("{% with x as y %}\n\n yeahhhhh");
+        tpl.render({}, function(err, data){
+            assert.strictEqual(data, null);
+            assert.ok(err instanceof Error);
+        });
+    })
+)
+
+test("Test that with is enabled by default", mocktimeout(function(assert) {
+
+        assert.doesNotThrow(function() {
+            var tpl = new plate.Template("{% with y=x %}\n\n{% endwith %}");
+            tpl.render({}, function(){});
+        });
+    })
+)
+
+test("Test that with adds the variable into context", mocktimeout(function(assert) {
+
+        var context = {
+            'value':~~(Math.random()*10)
+        };
+        var tpl = new plate.Template("{% with othervalue=value %}{{ othervalue }}{% endwith %}");
+        tpl.render(context, function(err, data) {
+            assert.strictEqual(err, null);
+            assert.equal(data, context.value.toString());
+        });
+    })
+)
+
+test("Test that with works with multiple assignments", mocktimeout(function(assert) {
+
+        var context = {
+            'value':~~(Math.random()*10),
+            'anothervalue':~(Math.random()*10)+10
+        };
+        var tpl = new plate.Template("{% with othervalue=value lastvalue=anothervalue %}{{ othervalue }}{{ lastvalue }}{% endwith %}");
+        tpl.render(context, function(err, data) {
+            assert.strictEqual(err, null);
+            assert.equal(data, context.value.toString()+context.anothervalue.toString());
+        });
+    })
+)
+
+test("Test that with does not leak context variables", mocktimeout(function(assert) {
+
+        var context = {
+            'value':'hi'+~~(Math.random()*10),
+            'othervalue':~~(Math.random()*10)+'yeah'
+        };
+        var tpl = new plate.Template("{% with othervalue=value %}{{ othervalue }}{% endwith %}{{ othervalue }}");
+        tpl.render(context, function(err, data) {
+            assert.strictEqual(err, null);
+            assert.equal(data, context.value.toString()+context.othervalue.toString());
+        });
+    })
+)
+
+test("Test that an unclosed with statement throws an error", mocktimeout(function(assert) {
+
+        var tpl = new plate.Template("{% with y=x %}\n\n yeahhhhh");
         tpl.render({}, function(err, data){
             assert.strictEqual(data, null);
             assert.ok(err instanceof Error);


### PR DESCRIPTION
Implements the new `with` tag syntax `{% with x=y %}` while keeping old-style syntax `{% with y as x %}` intact (since Django 1.3).

A lot of this (mainly the new `token_kwargs` utility function) has been ported straight from the appropriate [django sources](https://github.com/django/django/blob/1.6.2/django/template/base.py#L902).

Concerns:
- This may not be the correct place for `token_kwargs`; a new `tags/util.js` might make more sense, but the function is also only used in `tags/with.js`.  Happy to move it if you have a preferred / more appropriate place for it.
- ~~`WithNode.render` has lost a bit of code related to the second argument (`value`) and Promises.  I'm not familiar enough with the codebase to say for sure, but looking through the rest of the code, I couldn't find any solid evidence that this second argument is ever actually passed in normal usage.~~ See comment below.

FWIW, this implementation works for my templates which, at the moment, use a combination of old-style and new-style `with` tags.

Also, concerning code style, I didn't see any style guide, and there is no linter config in the repo, so I may have botched some style :grin:.  I tried to follow existing conventions, but I'm happy to tweak specific things if you'll point them out.
