### PR TITLE
Don't exit filter resolution early if the variable isn't in the context

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Got a feature you'd like to add? I'd love to see it. The workflow is pretty stan
 
 * Fork this repository.
 * Create a branch -- title it descriptively, please :)
-* Work, work, work. 
+* Work, work, work.
 * Push your changes and submit a pull request.
 
 The minimum requirements for a pull request to be merged are:

--- a/docs/A-Simple-Template-Tag.md
+++ b/docs/A-Simple-Template-Tag.md
@@ -37,7 +37,7 @@ A good first step is to write a simple, synchronous template tag -- in this case
   })
 ````
 
-The two required pieces for a template tag are the `Node` class and the `parse` function. 
+The two required pieces for a template tag are the `Node` class and the `parse` function.
 Whenever a '{% templatetagname %}' token is encountered, plate attempts to look up the registered
 parser for that name. If it's found, it calls the parse function with the string contents of that
 tag (sans leading and trailing whitespace) -- so `{% tag thing1 thing2 thing3 %}` will be call the 'tag'

--- a/lib/date.js
+++ b/lib/date.js
@@ -284,7 +284,7 @@ proto.O = function() {
   var tzoffs = this.data.getTimezoneOffset()
     , offs = ~~(tzoffs / 60)
     , mins = ('00' + ~~Math.abs(tzoffs % 60)).slice(-2)
-  
+
   return ((tzoffs > 0) ? '-' : '+') + ('00' + Math.abs(offs)).slice(-2) + mins
 }
 
@@ -339,7 +339,7 @@ proto.w = function() {
 proto.W = function() {
   // ISO-8601 week number of year, weeks starting on Monday
   // Algorithm from http://www.personal.ecu.edu/mccartyr/ISOwdALG.txt
-  var jan1_weekday = new Date(this.data.getFullYear(), 0, 1).getDay() 
+  var jan1_weekday = new Date(this.data.getFullYear(), 0, 1).getDay()
     , weekday = this.data.getDay()
     , day_of_year = this.z()
     , week_number

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,5 +1,5 @@
 module.exports = {
     log: function(value) { console.log(value) }
   , error: function(err) { console.error(err, err && err.stack) }
-  , info: function(value) { } 
+  , info: function(value) { }
 }

--- a/lib/express-shim.js
+++ b/lib/express-shim.js
@@ -37,10 +37,10 @@ module.exports = function(str, options) {
   return function(context) {
     var ee = new EE
     process.nextTick(tpl.render.bind(tpl, context, function(err, html) {
-      err ? 
+      err ?
         ee.emit('error', err) :
         ee.emit('data',  html)
     }))
     return ee
-  } 
+  }
 }

--- a/lib/filter_application.js
+++ b/lib/filter_application.js
@@ -39,7 +39,7 @@ proto.resolve = function(context, value, fromIDX, argValues) {
   }
 
   for(var i = start, len = self.args.length; i < len; ++i) {
-    var argValue = self.args[i].resolve ? 
+    var argValue = self.args[i].resolve ?
         self.args[i].resolve(context) :
         self.args[i]
 
@@ -53,7 +53,7 @@ proto.resolve = function(context, value, fromIDX, argValues) {
 
       argValue.once('done', function(val) {
         argValues[i] = val
-        promise.resolve(self.resolve( 
+        promise.resolve(self.resolve(
             context
           , value
           , i
@@ -81,7 +81,7 @@ proto.resolve = function(context, value, fromIDX, argValues) {
   return result
 
   function ready(err, data) {
-    if(promise.trigger) 
+    if(promise.trigger)
       return promise.resolve(err ? err : data)
 
     result = data

--- a/lib/filter_application.js
+++ b/lib/filter_application.js
@@ -24,10 +24,6 @@ proto.resolve = function(context, value, fromIDX, argValues) {
 
   argValues = argValues || []
 
-  if(value === undefined) {
-    return
-  }
-
   if(value && value.constructor === Promise) {
     promise = new Promise
     value.once('done', function(val) {

--- a/lib/filter_chain.js
+++ b/lib/filter_chain.js
@@ -9,7 +9,7 @@ var cons = FilterChain
 
 proto.attach = function(parser) {
   for(var i = 0, len = this.bits.length; i < len; ++i) {
-    if(this.bits[i] && this.bits[i].attach) { 
+    if(this.bits[i] && this.bits[i].attach) {
       this.bits[i].attach(parser)
     }
   }

--- a/lib/filter_lookup.js
+++ b/lib/filter_lookup.js
@@ -56,7 +56,7 @@ proto.resolve = function(context, fromIDX) {
       current = next
     }
 
-  } 
+  }
 
   return current
 }

--- a/lib/filter_node.js
+++ b/lib/filter_node.js
@@ -49,7 +49,7 @@ function safely(fn) {
     try {
       return fn.call(this, context)
     } catch(err) {
-      debug.info(err) 
+      debug.info(err)
       return ''
     }
   }

--- a/lib/filters/add.js
+++ b/lib/filters/add.js
@@ -1,3 +1,7 @@
 module.exports = function(input, value) {
-  return parseInt(input, 10) + parseInt(value, 10)
+  input = parseInt(input, 10);
+  value = parseInt(value, 10)
+  if (isNaN(input) || isNaN(value))
+    return ''
+  return input + value
 }

--- a/lib/filters/add.js
+++ b/lib/filters/add.js
@@ -1,7 +1,8 @@
 module.exports = function(input, value) {
   input = parseInt(input, 10);
   value = parseInt(value, 10)
-  if (isNaN(input) || isNaN(value))
+  if(isNaN(input) || isNaN(value)) {
     return ''
+  }
   return input + value
 }

--- a/lib/filters/addslashes.js
+++ b/lib/filters/addslashes.js
@@ -1,5 +1,6 @@
 module.exports = function(input) {
-  if (input === undefined || input === null)
+  if(input === undefined || input === null) {
     input = ''
+  }
   return input.toString().replace(/'/g, "\\'")
 }

--- a/lib/filters/addslashes.js
+++ b/lib/filters/addslashes.js
@@ -1,3 +1,5 @@
 module.exports = function(input) {
+  if (input === undefined || input === null)
+    input = ''
   return input.toString().replace(/'/g, "\\'")
 }

--- a/lib/filters/center.js
+++ b/lib/filters/center.js
@@ -1,4 +1,7 @@
 module.exports = function(input, len, ready) {
+  if (input === undefined || input === null)
+    input = ''
+
   if(ready === undefined)
     len = 0
 

--- a/lib/filters/center.js
+++ b/lib/filters/center.js
@@ -1,9 +1,11 @@
 module.exports = function(input, len, ready) {
-  if (input === undefined || input === null)
+  if(input === undefined || input === null) {
     input = ''
+  }
 
-  if(ready === undefined)
+  if(ready === undefined) {
     len = 0
+  }
 
   var str = input.toString()
     , value = ' '

--- a/lib/filters/center.js
+++ b/lib/filters/center.js
@@ -6,7 +6,7 @@ module.exports = function(input, len, ready) {
     , value = ' '
 
   len -= str.length
-  if(len < 0) { 
+  if(len < 0) {
     return str
   }
 
@@ -23,6 +23,6 @@ module.exports = function(input, len, ready) {
   if((len_half - Math.floor(len_half)) > 0) {
     str = input.toString().length % 2 == 0 ? value + str : str + value
   }
-  
+
   return str
 }

--- a/lib/filters/date.js
+++ b/lib/filters/date.js
@@ -1,5 +1,5 @@
 var format = require('../date').date
-  
+
 module.exports = function(input, value, ready) {
   if (ready === undefined)
     value = 'N j, Y'

--- a/lib/filters/date.js
+++ b/lib/filters/date.js
@@ -1,8 +1,9 @@
 var format = require('../date').date
 
 module.exports = function(input, value, ready) {
-  if (ready === undefined)
+  if(ready === undefined) {
     value = 'N j, Y'
+  }
 
   return format(input.getFullYear ? input : new Date(input), value)
 }

--- a/lib/filters/dictsort.js
+++ b/lib/filters/dictsort.js
@@ -1,6 +1,7 @@
 module.exports = function(input, key) {
-  if (input === undefined || input === null)
+  if(input === undefined || input === null) {
     input = []
+  }
 
   return input.sort(function(x, y) {
     if(x[key] > y[key]) return 1

--- a/lib/filters/dictsort.js
+++ b/lib/filters/dictsort.js
@@ -1,4 +1,7 @@
 module.exports = function(input, key) {
+  if (input === undefined || input === null)
+    input = []
+
   return input.sort(function(x, y) {
     if(x[key] > y[key]) return 1
     if(x[key] == y[key]) return 0

--- a/lib/filters/divisibleby.js
+++ b/lib/filters/divisibleby.js
@@ -1,6 +1,7 @@
 module.exports = function(input, num) {
-  if (isNaN(parseInt(input)))
+  if(isNaN(parseInt(input))) {
     throw new Error('Invalid input for divisibleby: ' + String(input))
+  }
 
   return input % parseInt(num, 10) == 0
 }

--- a/lib/filters/divisibleby.js
+++ b/lib/filters/divisibleby.js
@@ -1,3 +1,6 @@
 module.exports = function(input, num) {
+  if (isNaN(parseInt(input)))
+    throw new Error('Invalid input for divisibleby: ' + String(input))
+
   return input % parseInt(num, 10) == 0
 }

--- a/lib/filters/escape.js
+++ b/lib/filters/escape.js
@@ -1,6 +1,10 @@
 var FilterNode = require('../filter_node')
 
 module.exports = function(input) {
+  if (input === undefined) {
+    input = ''
+  }
+
   if(input && input.safe) {
     return input
   }

--- a/lib/filters/escape.js
+++ b/lib/filters/escape.js
@@ -1,7 +1,7 @@
 var FilterNode = require('../filter_node')
 
 module.exports = function(input) {
-  if (input === undefined) {
+  if(input === undefined) {
     input = ''
   }
 

--- a/lib/filters/filesizeformat.js
+++ b/lib/filters/filesizeformat.js
@@ -3,8 +3,9 @@ module.exports = function(input) {
     , singular = num == 1 ? '' : 's'
     , value
 
-  if (isNaN(num))
+  if(isNaN(num)) {
     num = 0
+  }
 
   value =
     num < 1024 ? num + ' byte'+singular :

--- a/lib/filters/filesizeformat.js
+++ b/lib/filters/filesizeformat.js
@@ -3,6 +3,9 @@ module.exports = function(input) {
     , singular = num == 1 ? '' : 's'
     , value
 
+  if (isNaN(num))
+    num = 0
+
   value =
     num < 1024 ? num + ' byte'+singular :
     num < (1024*1024) ? (num/1024)+' KB' :

--- a/lib/filters/filesizeformat.js
+++ b/lib/filters/filesizeformat.js
@@ -1,8 +1,8 @@
 module.exports = function(input) {
   var num = (new Number(input)).valueOf()
     , singular = num == 1 ? '' : 's'
-    , value 
-    
+    , value
+
   value =
     num < 1024 ? num + ' byte'+singular :
     num < (1024*1024) ? (num/1024)+' KB' :

--- a/lib/filters/floatformat.js
+++ b/lib/filters/floatformat.js
@@ -9,13 +9,15 @@ module.exports = function(input, val) {
     , pow_minus_one = Math.pow(10, Math.max(absValue-1, 0))
     , asString
 
-  if (isNaN(asNumber))
+  if(isNaN(asNumber)) {
     return ''
+  }
 
   asNumber = Math.round((pow * asNumber) / pow_minus_one)
 
-  if(val !== 0)
+  if(val !== 0) {
     asNumber /= 10
+  }
 
   asString = asNumber.toString()
 

--- a/lib/filters/floatformat.js
+++ b/lib/filters/floatformat.js
@@ -9,6 +9,9 @@ module.exports = function(input, val) {
     , pow_minus_one = Math.pow(10, Math.max(absValue-1, 0))
     , asString
 
+  if (isNaN(asNumber))
+    return ''
+
   asNumber = Math.round((pow * asNumber) / pow_minus_one)
 
   if(val !== 0)

--- a/lib/filters/force_escape.js
+++ b/lib/filters/force_escape.js
@@ -1,8 +1,9 @@
 var FilterNode = require('../filter_node')
 
 module.exports = function(input) {
-  if (input === undefined)
+  if(input === undefined) {
     input = ''
+  }
 
   var x = new String(FilterNode.escape(input+''))
   x.safe = true

--- a/lib/filters/force_escape.js
+++ b/lib/filters/force_escape.js
@@ -1,6 +1,9 @@
 var FilterNode = require('../filter_node')
 
 module.exports = function(input) {
+  if (input === undefined)
+    input = ''
+
   var x = new String(FilterNode.escape(input+''))
   x.safe = true
   return x

--- a/lib/filters/length.js
+++ b/lib/filters/length.js
@@ -1,6 +1,11 @@
 module.exports = function(input, ready) {
-  if(input && typeof input.length === 'function') {
-    return input.length(ready)
+  if(input) {
+    if (typeof input.length === 'function') {
+      return input.length(ready)
+    }
+    else {
+      return input.length
+    }
   }
-  return input.length
+  return 0
 }

--- a/lib/filters/length.js
+++ b/lib/filters/length.js
@@ -2,8 +2,7 @@ module.exports = function(input, ready) {
   if(input) {
     if (typeof input.length === 'function') {
       return input.length(ready)
-    }
-    else {
+    } else {
       return input.length
     }
   }

--- a/lib/filters/length_is.js
+++ b/lib/filters/length_is.js
@@ -1,12 +1,16 @@
 module.exports = function(input, expected, ready) {
   var tmp
-  if(input && typeof input.length === 'function') {
-    tmp = input.length(function(err, len) {
-      ready(err, err ? null : len === expected)
-    })
+  if(input) {
+    if (typeof input.length === 'function') {
+      tmp = input.length(function(err, len) {
+        ready(err, err ? null : len === expected)
+      })
 
-    return tmp === undefined ? undefined : tmp === expected
+      return tmp === undefined ? undefined : tmp === expected
+    }
+    else {
+      return input.length === expected
+    }
   }
-
-  return input.length === expected
+  return 0 === expected
 }

--- a/lib/filters/length_is.js
+++ b/lib/filters/length_is.js
@@ -7,8 +7,7 @@ module.exports = function(input, expected, ready) {
       })
 
       return tmp === undefined ? undefined : tmp === expected
-    }
-    else {
+    } else {
       return input.length === expected
     }
   }

--- a/lib/filters/linebreaks.js
+++ b/lib/filters/linebreaks.js
@@ -1,6 +1,9 @@
 var safe = require('./safe')
 
 module.exports = function(input) {
+  if (input === undefined || input === null)
+    input = ''
+
   var str = input.toString()
     , paras = str.split('\n\n')
     , out = []

--- a/lib/filters/linebreaks.js
+++ b/lib/filters/linebreaks.js
@@ -1,8 +1,9 @@
 var safe = require('./safe')
 
 module.exports = function(input) {
-  if (input === undefined || input === null)
+  if(input === undefined || input === null) {
     input = ''
+  }
 
   var str = input.toString()
     , paras = str.split('\n\n')

--- a/lib/filters/linebreaksbr.js
+++ b/lib/filters/linebreaksbr.js
@@ -1,8 +1,9 @@
 var safe = require('./safe')
 
 module.exports = function(input) {
-  if (input === undefined || input === null)
+  if(input === undefined || input === null) {
     input = ''
+  }
 
   var str = input.toString()
   return safe(str.replace(/\n/g, '<br />'))

--- a/lib/filters/linebreaksbr.js
+++ b/lib/filters/linebreaksbr.js
@@ -1,6 +1,9 @@
 var safe = require('./safe')
 
 module.exports = function(input) {
+  if (input === undefined || input === null)
+    input = ''
+
   var str = input.toString()
   return safe(str.replace(/\n/g, '<br />'))
 }

--- a/lib/filters/linenumbers.js
+++ b/lib/filters/linenumbers.js
@@ -1,6 +1,7 @@
 module.exports = function(input) {
-  if (input === undefined || input === null)
+  if(input === undefined || input === null) {
     input = ''
+  }
 
   var str = input.toString()
     , bits = str.split('\n')

--- a/lib/filters/linenumbers.js
+++ b/lib/filters/linenumbers.js
@@ -1,4 +1,7 @@
 module.exports = function(input) {
+  if (input === undefined || input === null)
+    input = ''
+
   var str = input.toString()
     , bits = str.split('\n')
     , out = []

--- a/lib/filters/make_list.js
+++ b/lib/filters/make_list.js
@@ -1,6 +1,7 @@
 module.exports = function(input) {
-  if (input === undefined || input === null)
+  if(input === undefined || input === null) {
     input = ''
+  }
 
   input = input instanceof Array ? input : input.toString().split('')
 

--- a/lib/filters/make_list.js
+++ b/lib/filters/make_list.js
@@ -1,4 +1,7 @@
 module.exports = function(input) {
+  if (input === undefined || input === null)
+    input = ''
+
   input = input instanceof Array ? input : input.toString().split('')
 
   return input

--- a/lib/filters/pluralize.js
+++ b/lib/filters/pluralize.js
@@ -6,7 +6,7 @@ module.exports = function(input, plural) {
 
   suffix = plural[plural.length-1];
   if(val === 1) {
-    suffix = plural.length > 1 ? plural[0] : '';    
+    suffix = plural.length > 1 ? plural[0] : '';
   }
 
   return suffix

--- a/lib/filters/pluralize.js
+++ b/lib/filters/pluralize.js
@@ -4,8 +4,9 @@ module.exports = function(input, plural) {
   var val = Number(input)
     , suffix
 
-  if (isNaN(val))
+  if(isNaN(val)) {
     val = 1
+  }
 
   suffix = plural[plural.length-1];
   if(val === 1) {

--- a/lib/filters/pluralize.js
+++ b/lib/filters/pluralize.js
@@ -4,6 +4,9 @@ module.exports = function(input, plural) {
   var val = Number(input)
     , suffix
 
+  if (isNaN(val))
+    val = 1
+
   suffix = plural[plural.length-1];
   if(val === 1) {
     suffix = plural.length > 1 ? plural[0] : '';

--- a/lib/filters/random.js
+++ b/lib/filters/random.js
@@ -1,6 +1,6 @@
 module.exports = function(input) {
   if (!input)
-    throw new Error('Invalid input for random: ' + String(input))
+    return null
 
   var cb = input.charAt || function(idx) {
     return this[idx];

--- a/lib/filters/random.js
+++ b/lib/filters/random.js
@@ -1,6 +1,7 @@
 module.exports = function(input) {
-  if (!input)
+  if(!input) {
     return null
+  }
 
   var cb = input.charAt || function(idx) {
     return this[idx];

--- a/lib/filters/random.js
+++ b/lib/filters/random.js
@@ -1,4 +1,7 @@
 module.exports = function(input) {
+  if (!input)
+    throw new Error('Invalid input for random: ' + String(input))
+
   var cb = input.charAt || function(idx) {
     return this[idx];
   };

--- a/lib/filters/safe.js
+++ b/lib/filters/safe.js
@@ -1,8 +1,9 @@
 var FilterNode = require('../filter_node')
 
 module.exports = function(input) {
-  if (input === undefined)
+  if(input === undefined) {
     input = ''
+  }
 
   input = new String(input)
   input.safe = true

--- a/lib/filters/safe.js
+++ b/lib/filters/safe.js
@@ -1,6 +1,9 @@
 var FilterNode = require('../filter_node')
 
 module.exports = function(input) {
+  if (input === undefined)
+    input = ''
+
   input = new String(input)
   input.safe = true
   return input

--- a/lib/filters/slice.js
+++ b/lib/filters/slice.js
@@ -1,6 +1,7 @@
 module.exports = function(input, by) {
-  if (input === undefined || input === null)
+  if(input === undefined || input === null) {
     input = []
+  }
 
   by = by.toString()
   if(by.charAt(0) === ':') {

--- a/lib/filters/slice.js
+++ b/lib/filters/slice.js
@@ -1,4 +1,7 @@
 module.exports = function(input, by) {
+  if (input === undefined || input === null)
+    input = []
+
   by = by.toString()
   if(by.charAt(0) === ':') {
     by = '0'+by

--- a/lib/filters/time.js
+++ b/lib/filters/time.js
@@ -1,8 +1,9 @@
 var time_format = require('../date').time
 
 module.exports = function(input, value) {
-  if (value === null)
+  if(value === null) {
     value = 'H:M:S'
+  }
 
   return time_format(input, value)
 }

--- a/lib/filters/timesince.js
+++ b/lib/filters/timesince.js
@@ -4,8 +4,9 @@ module.exports = function(input, n, ready) {
     , diff  = input - now
     , since = Math.abs(diff)
 
-  if(diff > 0)
+  if(diff > 0) {
     return '0 minutes'
+  }
 
   // 365.25 * 24 * 60 * 60 * 1000 === years
   var years =   ~~(since / 31557600000)

--- a/lib/filters/title.js
+++ b/lib/filters/title.js
@@ -2,7 +2,7 @@ module.exports = function(input) {
   var str = input.toString()
     , bits = str.split(/\s{1}/g)
     , out = []
-  
+
   while(bits.length) {
     var word = bits.shift()
     word = word.charAt(0).toUpperCase() + word.slice(1)

--- a/lib/filters/truncatechars.js
+++ b/lib/filters/truncatechars.js
@@ -2,11 +2,13 @@ module.exports = function(input, n) {
   var str = input.toString()
     , num = parseInt(n, 10)
 
-  if(isNaN(num))
+  if(isNaN(num)) {
     return input
+  }
 
-  if(input.length <= num)
+  if(input.length <= num) {
     return input
+  }
 
   return input.slice(0, num)+'...'
 }

--- a/lib/filters/truncatewords.js
+++ b/lib/filters/truncatewords.js
@@ -3,13 +3,15 @@ module.exports = function(input, n) {
     , num = parseInt(n, 10)
     , words
 
-  if(isNaN(num))
+  if(isNaN(num)) {
     return input
+  }
 
   words = input.split(/\s+/)
 
-  if(words.length <= num)
+  if(words.length <= num) {
     return input
+  }
 
   return words.slice(0, num).join(' ')+'...'
 }

--- a/lib/filters/unordered_list.js
+++ b/lib/filters/unordered_list.js
@@ -8,10 +8,11 @@ var ulparser = function(list) {
   while(l.length) {
     item = l.pop()
 
-    if(item instanceof Array)
+    if(item instanceof Array) {
       out.unshift('<ul>'+ulparser(item)+'</ul>')
-    else
+    } else {
       out.unshift('</li><li>'+item)
+    }
   }
 
   // get rid of the leading </li>, if any. add trailing </li>.

--- a/lib/filters/wordcount.js
+++ b/lib/filters/wordcount.js
@@ -1,4 +1,7 @@
 module.exports = function(input) {
+  if (input === undefined || input === null)
+    return 0
+
   var str = input.toString()
     , bits = str.split(/\s+/g)
 

--- a/lib/filters/wordcount.js
+++ b/lib/filters/wordcount.js
@@ -1,6 +1,7 @@
 module.exports = function(input) {
-  if (input === undefined || input === null)
+  if(input === undefined || input === null) {
     return 0
+  }
 
   var str = input.toString()
     , bits = str.split(/\s+/g)

--- a/lib/filters/yesno.js
+++ b/lib/filters/yesno.js
@@ -1,6 +1,7 @@
 module.exports = function(input, map) {
-  if (input === undefined)
+  if(input === undefined) {
     input = false
+  }
 
   var ourMap = map.toString().split(',')
     , value

--- a/lib/filters/yesno.js
+++ b/lib/filters/yesno.js
@@ -1,4 +1,7 @@
 module.exports = function(input, map) {
+  if (input === undefined)
+    input = false
+
   var ourMap = map.toString().split(',')
     , value
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 var FilterToken = require('./filter_token')
   , TagToken = require('./tag_token')
   , CommentToken = require('./comment_token')
-  , TextToken = require('./text_token') 
+  , TextToken = require('./text_token')
   , libraries = require('./libraries')
   , Parser = require('./parser')
   , Context = require('./context')
@@ -15,7 +15,7 @@ module.exports = Template
 Template.Template = Template
 Template.Context = Context
 
-var later = typeof global !== 'undefined' ? 
+var later = typeof global !== 'undefined' ?
     function(fn) { global.setTimeout(fn, 0) } :
     function(fn) { this.setTimeout(fn, 0) }
 
@@ -31,10 +31,10 @@ function Template(raw, libraries, parser) {
   this.tagLibrary =
     libraries.tag_library || Template.Meta.createTagLibrary()
 
-  this.filterLibrary = 
+  this.filterLibrary =
     libraries.filter_library || Template.Meta.createFilterLibrary()
 
-  this.pluginLibrary = 
+  this.pluginLibrary =
     libraries.plugin_library || Template.Meta.createPluginLibrary()
 
   this.parser = parser || Parser
@@ -77,7 +77,7 @@ proto.render = protect(function(context, ready) {
 
   var result
 
-  result = 
+  result =
   this
     .getNodeList()
     .render(context)

--- a/lib/libraries.js
+++ b/lib/libraries.js
@@ -3,4 +3,4 @@ module.exports = {
   , DefaultPluginLibrary: require('./library')
   , DefaultTagLibrary: require('./defaulttags')
   , DefaultFilterLibrary: require('./defaultfilters')
-} 
+}

--- a/lib/meta.js
+++ b/lib/meta.js
@@ -41,7 +41,7 @@ function createAutoregister(name) {
 function createLibrary(name) {
   return function() {
     if(this._cache[name])
-      return this._cache[name]; 
+      return this._cache[name];
 
     var lib = new this._classes[name]
 

--- a/lib/node_list.js
+++ b/lib/node_list.js
@@ -24,7 +24,7 @@ proto.render = function(context) {
   }
 
   if(promises.length) {
-    return this.resolvePromises(results, promises) 
+    return this.resolvePromises(results, promises)
   }
 
   return results.join('')
@@ -36,7 +36,7 @@ proto.resolvePromises = function(results, promises) {
     , total = promises.length
 
   for(var i = 0, p = 0, len = results.length; i < len; ++i) {
-    if(results[i].constructor !== Promise) 
+    if(results[i].constructor !== Promise)
       continue
 
     promises[p++].once('done', bind(i, function(idx, result) {

--- a/lib/plugins/loaders/filesystem.js
+++ b/lib/plugins/loaders/filesystem.js
@@ -29,7 +29,7 @@ Loader.prototype.lookup = function(name, dirs) {
 
   if(self.cache[name]) {
     return self.cache[name]
-  } 
+  }
 
   // XXX: should throw error here.
   if(!dirs.length)
@@ -44,7 +44,7 @@ Loader.prototype.lookup = function(name, dirs) {
   return promise
 
   function gotDirectory(err, data) {
-    promise.resolve(err ? self.lookup(name, dirs) : self.cache[name] = self.createTemplate(data)) 
+    promise.resolve(err ? self.lookup(name, dirs) : self.cache[name] = self.createTemplate(data))
   }
 
 }

--- a/lib/tags/block.js
+++ b/lib/tags/block.js
@@ -27,9 +27,9 @@ proto.render = function(context) {
 
   block = push = blockContext.pop(self.name)
 
-  if(!block) { 
+  if(!block) {
     block = self
-  } 
+  }
 
   block = new BlockNode(block.name, block.nodes)
 
@@ -57,7 +57,7 @@ proto._super = function() {
   if(blockContext && (block = blockContext.get(this.name))) {
     str = new String(block.render(this.context))
     str.safe = true
-    return str 
+    return str
   }
 
   return ''
@@ -78,5 +78,5 @@ cons.parse = function(contents, parser) {
   nodes = parser.parse(['endblock'])
   parser.tokens.shift()
 
-  return new cons(name, nodes)  
+  return new cons(name, nodes)
 }

--- a/lib/tags/extends.js
+++ b/lib/tags/extends.js
@@ -46,7 +46,7 @@ proto.render = function(context, parent) {
 
     parent.once('done', function(data) {
       promise.resolve(self.render(context, data))
-    })  
+    })
 
     return promise
   }

--- a/lib/tags/for.js
+++ b/lib/tags/for.js
@@ -19,7 +19,7 @@ function getInIndex(bits) {
     if(bits[i] === 'in')
       return i
 
-  return -1 
+  return -1
 }
 
 proto.render = function(context, value) {
@@ -73,7 +73,7 @@ proto.render = function(context, value) {
     loop.revcounter0 = len - (i + 1)
     loop.first = i === 0
     loop.last = i === len - 1
-    loop.parentloop = parent 
+    loop.parentloop = parent
     ctxt.forloop = loop
 
     if(self.unpack.length === 1)
@@ -84,8 +84,8 @@ proto.render = function(context, value) {
     result = self.loop.render(ctxt)
     if(result.constructor === Promise)
       promises.push(result)
-     
-    bits.push(result) 
+
+    bits.push(result)
   }
 
   if(promises.length) {

--- a/lib/tags/if/infix.js
+++ b/lib/tags/if/infix.js
@@ -6,9 +6,9 @@ function InfixOperator(bp, cmp) {
   this.lbp = bp
   this.cmp = cmp
 
-  this.first = 
+  this.first =
   this.second = null
-} 
+}
 
 var cons = InfixOperator
   , proto = cons.prototype

--- a/lib/tags/if/operators.js
+++ b/lib/tags/if/operators.js
@@ -45,43 +45,43 @@ module.exports = {
   }
 
   , '=': function() {
-    return new InfixOperator(10, function(x, y) { 
+    return new InfixOperator(10, function(x, y) {
       return x == y
     })
   }
 
   , '==': function() {
-      return new InfixOperator(10, function(x, y) { 
+      return new InfixOperator(10, function(x, y) {
         return x == y
       })
     }
 
   , '!=': function() {
-      return new InfixOperator(10, function(x, y) { 
+      return new InfixOperator(10, function(x, y) {
         return x !== y
       })
     }
 
   , '>': function() {
-      return new InfixOperator(10, function(x, y) { 
+      return new InfixOperator(10, function(x, y) {
         return x > y
       })
     }
 
   , '>=': function() {
-      return new InfixOperator(10, function(x, y) { 
+      return new InfixOperator(10, function(x, y) {
         return x >= y
       })
     }
 
   , '<': function() {
-      return new InfixOperator(10, function(x, y) { 
+      return new InfixOperator(10, function(x, y) {
         return x < y
       })
     }
 
   , '<=': function() {
-      return new InfixOperator(10, function(x, y) { 
+      return new InfixOperator(10, function(x, y) {
         return x <= y
       })
     }
@@ -123,7 +123,7 @@ function in_operator(x, y) {
       var xkeys = keys(x),
         rkeys = keys(rhs)
 
-      if(xkeys.length === rkeys.length) { 
+      if(xkeys.length === rkeys.length) {
         for(var i = 0, len = xkeys.length, equal = true;
           i < len && equal;
           ++i) {
@@ -131,7 +131,7 @@ function in_operator(x, y) {
               x[xkeys[i]] === rhs[rkeys[i]]
         }
         found = equal
-      } 
+      }
     } else {
       found = x == rhs
     }

--- a/lib/tags/if/prefix.js
+++ b/lib/tags/if/prefix.js
@@ -6,7 +6,7 @@ function PrefixOperator(bp, cmp) {
   this.lbp = bp
   this.cmp = cmp
 
-  this.first = 
+  this.first =
   this.second = null
 }
 

--- a/lib/tags/include.js
+++ b/lib/tags/include.js
@@ -15,7 +15,7 @@ cons.parse = function(contents, parser) {
     , varname = parser.compile(bits.slice(1).join(' '))
     , loader = parser.plugins.lookup('loader')
 
-  return new cons(varname, loader) 
+  return new cons(varname, loader)
 }
 
 proto.render = function(context, target) {
@@ -41,7 +41,7 @@ proto.render = function(context, target) {
 
     target.once('done', function(data) {
       promise.resolve(self.render(context, data))
-    })  
+    })
 
     return promise
   }

--- a/lib/tags/with.js
+++ b/lib/tags/with.js
@@ -22,7 +22,7 @@ cons.parse = function(contents, parser) {
 }
 
 proto.render = function(context, value) {
-  var self = this 
+  var self = this
     , result
     , promise
 

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -144,7 +144,7 @@ test("Test that the date filter defaults to 'N j, Y'", mocktimeout(function(asse
         tpl.render({test:dt}, function(err, data) {
             assert.equal(data, now)
         })
-        template.render({}, function(err, data) {
+        tpl.render({}, function(err, data) {
             assert.equal(data, '')
         })
     })

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -55,7 +55,7 @@ test("Test that the addslashes filter works as expected", mocktimeout(function(a
             assert.equal(data.split('\\').length, num+1);
         });
         tpl.render({}, function(err, data) {
-            assert.ok(err);
+            assert.equal(data, '');
         });
     })
 )
@@ -338,7 +338,7 @@ test("Test that the floatformat filter works as expected", mocktimeout(function(
         var tpl = new plate.Template(
                 "{% for x,y in values %}{{ forloop.counter0 }}:{{ x|floatformat:y }}\n{% endfor %}"
             ),
-            tpl_missing_var = new plate.Template("{% x|floatformat %}")
+            tpl_missing_var = new plate.Template("{{ x|floatformat }}")
             context = {
                 'values':[]
             };
@@ -1418,7 +1418,7 @@ test("Test that the yesno filter coerces values into true,false,maybe", mocktime
           assert.equal(bits[i], mode);
         }
       });
-      tpl.render({}, function(err, data) {
+      tpl_missing_var.render({}, function(err, data) {
         assert.equal(data, 'falsy');
       });
     })

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -802,12 +802,12 @@ test("Assert that random pulls an item out of an array randomly.", mocktimeout(f
     })
 )
 
-test("Assert that random throws an error on missing variables.", mocktimeout(function(assert) {
+test("Assert that random doesn't break on missing variables.", mocktimeout(function(assert) {
 
       var tpl = new plate.Template('{{ list|random }}');
 
       tpl.render({}, function(err, data) {
-        assert.ok(err);
+        assert.equal(data, '');
       });
     })
 )

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -1163,8 +1163,6 @@ test("Assert that wordwrap wraps lines at a given number.", mocktimeout(function
 
 test("Test that the yesno filter coerces values into truthy,falsy", mocktimeout(function(assert) {
 
-      return
-
       var tpl = new plate.Template('{% for value in values %}{{ value|yesno:"truthy,falsy" }}\n{% endfor %}'),
           context = {
             values:[true, 1, {}, [], false, null]

--- a/tests/mocktimeout.js
+++ b/tests/mocktimeout.js
@@ -1,4 +1,4 @@
-var world = typeof global !== 'undefined' ? global : this 
+var world = typeof global !== 'undefined' ? global : this
 
 module.exports = function mocktimeout(fn) {
   return function(assert) {

--- a/tests/plate.js
+++ b/tests/plate.js
@@ -4,14 +4,14 @@ var plate = require('../index')
   , mocktimeout = require('./mocktimeout')
 
 test("Test the exception cases of plate.Template.", mocktimeout(function(assert) {
-        
+
         assert.throws(function() {
             var tpl = new plate.Template(2);
         });
         assert.throws(function() {
             var tpl = new plate.Template();
         });
-        
+
         var tplstr = "random-"+Math.random(),
             tpl = new plate.Template(tplstr);
 
@@ -39,7 +39,7 @@ test("Test the exception cases of plate.Template.", mocktimeout(function(assert)
     }))
 
 test("Test that encountering a {% tag %} will lookup that tag in the provided library", mocktimeout(function(assert) {
-        
+
         var lib = new platelib.Library(),
             name = "random_"+~~Math.random(),
             value = Math.random().toString(),
@@ -58,7 +58,7 @@ test("Test that encountering a {% tag %} will lookup that tag in the provided li
     }))
 
 test("Test that filter nodes render as expected.", mocktimeout(function(assert) {
-        
+
         var testContext = {
             value:Math.random().toString(),
             deep:{
@@ -101,23 +101,23 @@ test("Test that filter nodes render as expected.", mocktimeout(function(assert) 
 )
 
 test("Test that hitting an unknown tag triggers an error.", mocktimeout(function(assert) {
-        
+
         var tpl = new plate.Template("{% lol dne %}");
         tpl.render({}, function(err, data) {
             assert.strictEqual(data, null);
-            assert.ok(err instanceof Error); 
+            assert.ok(err instanceof Error);
         });
     })
 )
 
 test("Test that autoregistration of the tag library works as expected.", mocktimeout(function(assert) {
-      
+
       var expected = ~~(Math.random()*100);
       var tag = {
         render:function(context, ready) {
           return expected
         }
-      }; 
+      };
       plate.Template.Meta.registerTag('lolwut', function() { return tag; });
 
       assert.doesNotThrow(function() {
@@ -130,7 +130,7 @@ test("Test that autoregistration of the tag library works as expected.", mocktim
 )
 
 test("Test that autoregistration of the filter library works as expected.", mocktimeout(function(assert) {
-      
+
       var expected = ~~(Math.random()*100);
       var testFilter = function(input) {
         return expected
@@ -148,7 +148,7 @@ test("Test that autoregistration of the filter library works as expected.", mock
 )
 
 test("Test that autoregistration of the plugin library works as expected.", mocktimeout(function(assert) {
-      
+
       var expected = ~~(Math.random()*100);
       var plugin = function() {
         return ''+expected;

--- a/tests/plugins.js
+++ b/tests/plugins.js
@@ -8,13 +8,13 @@ var plate = require('../index'),
     mocktimeout = require('./mocktimeout')
 
 test("Test that the filesystem loader returns templates from filesystem.", function(assert) {
-        
+
         var loader = new filesystem.Loader(
                 [path.join(__dirname, 'templates')]
             );
 
         var p = loader.lookup('test.html')
-        
+
         p.once('done', function(template) {
             assert.ok(template instanceof plate.Template);
             assert.end()
@@ -23,9 +23,9 @@ test("Test that the filesystem loader returns templates from filesystem.", funct
 )
 
 test("Test that the filesystem loader works with the extends tag", function(assert) {
-        
+
         var lib = new libraries.Library(),
-            loader = new filesystem.Loader( 
+            loader = new filesystem.Loader(
                 [path.join(__dirname, 'templates')]
             );
 

--- a/tests/tags.js
+++ b/tests/tags.js
@@ -17,7 +17,7 @@ test("Test malformed {% if %} tag", mocktimeout(function(assert) {
 }))
 
 test("Test that for is enabled by default", mocktimeout(function(assert) {
-        
+
         var tpl = new plate.Template("{% for x in y %}{% empty %}{% endfor %}");
 
         assert.doesNotThrow(function() {
@@ -35,7 +35,7 @@ test("Test that for - empty works", mocktimeout(function(assert) {
 }))
 
 test("Test that for does not bubble errors if it cannot find the appropriate arrayVar", mocktimeout(function(assert) {
-        
+
         var tpl = new plate.Template("{% for x in y %}{% endfor %}");
 
         tpl.render({}, function(err, data) {
@@ -45,7 +45,7 @@ test("Test that for does not bubble errors if it cannot find the appropriate arr
 )
 
 test("Test that entering a for loop provides the forloop.counter", mocktimeout(function(assert) {
-        
+
         var size = ~~(Math.random()*10)+1,
             arr = [],
             context = {};
@@ -65,7 +65,7 @@ test("Test that entering a for loop provides the forloop.counter", mocktimeout(f
 )
 
 test("Test that entering a for loop provides the forloop.counter0", mocktimeout(function(assert) {
-        
+
         var size = ~~(Math.random()*10)+1,
             arr = [],
             context = {};
@@ -85,7 +85,7 @@ test("Test that entering a for loop provides the forloop.counter0", mocktimeout(
 )
 
 test("Test that entering a for loop provides the forloop.revcounter", mocktimeout(function(assert) {
-        
+
         var size = ~~(Math.random()*10)+1,
             arr = [],
             context = {};
@@ -105,7 +105,7 @@ test("Test that entering a for loop provides the forloop.revcounter", mocktimeou
 )
 
 test("Test that entering a for loop provides the forloop.revcounter0", mocktimeout(function(assert) {
-        
+
         var size = ~~(Math.random()*10)+1,
             arr = [],
             context = {};
@@ -125,7 +125,7 @@ test("Test that entering a for loop provides the forloop.revcounter0", mocktimeo
 )
 
 test("Test that entering a for loop provides the forloop.first", mocktimeout(function(assert) {
-        
+
         var size = ~~(Math.random()*10)+1,
             arr = [],
             context = {};
@@ -145,7 +145,7 @@ test("Test that entering a for loop provides the forloop.first", mocktimeout(fun
 )
 
 test("Test that entering a for loop provides the forloop.last", mocktimeout(function(assert) {
-        
+
         var size = ~~(Math.random()*10)+1,
             arr = [],
             context = {};
@@ -165,7 +165,7 @@ test("Test that entering a for loop provides the forloop.last", mocktimeout(func
 )
 
 test("Test that entering a nested forloop provides forloop.parentloop", mocktimeout(function(assert) {
-        
+
         var size = ~~(Math.random()*10)+1,
             arr = [],
             context = {};
@@ -188,7 +188,7 @@ test("Test that entering a nested forloop provides forloop.parentloop", mocktime
 )
 
 test("Test that for unpacks variables as needed", mocktimeout(function(assert) {
-        
+
         var size = ~~(Math.random()*10)+1,
             arr = [],
             context = {};
@@ -205,7 +205,7 @@ test("Test that for unpacks variables as needed", mocktimeout(function(assert) {
 
             assert.strictEqual(err, null);
             assert.equal(items.length, size);
-            
+
             for(i = 0; i < size; ++i) {
                 assert.equal(items[i], arr[i].join(','));
             }
@@ -214,7 +214,7 @@ test("Test that for unpacks variables as needed", mocktimeout(function(assert) {
 )
 
 test("Test that for can reverse the contents of an array prior to iteration", mocktimeout(function(assert) {
-        
+
         var size = ~~(Math.random()*10)+1,
             arr = [],
             context = {};
@@ -231,7 +231,7 @@ test("Test that for can reverse the contents of an array prior to iteration", mo
 
             assert.strictEqual(err, null);
             assert.equal(items.length, size);
- 
+
             for(i = 0; i < size; ++i) {
                 assert.equal(items[i], arr[(size-1)-i].join(','));
             }
@@ -240,7 +240,7 @@ test("Test that for can reverse the contents of an array prior to iteration", mo
 )
 
 test("Test that the with is enabled by default", mocktimeout(function(assert) {
-        
+
         assert.doesNotThrow(function() {
             var tpl = new plate.Template("{% with x as y %}\n\n{% endwith %}");
             tpl.render({}, function(){});
@@ -249,7 +249,7 @@ test("Test that the with is enabled by default", mocktimeout(function(assert) {
 )
 
 test("Test that with adds the variable into context", mocktimeout(function(assert) {
-        
+
         var context = {
             'value':~~(Math.random()*10)
         };
@@ -262,7 +262,7 @@ test("Test that with adds the variable into context", mocktimeout(function(asser
 )
 
 test("Test that with does not leak context variables", mocktimeout(function(assert) {
-        
+
         var context = {
             'value':'hi'+~~(Math.random()*10),
             'othervalue':~~(Math.random()*10)+'yeah'
@@ -276,7 +276,7 @@ test("Test that with does not leak context variables", mocktimeout(function(asse
 )
 
 test("Test that an unclosed with statement throws an error", mocktimeout(function(assert) {
-        
+
         var tpl = new plate.Template("{% with x as y %}\n\n yeahhhhh");
         tpl.render({}, function(err, data){
             assert.strictEqual(data, null);
@@ -286,7 +286,7 @@ test("Test that an unclosed with statement throws an error", mocktimeout(functio
 )
 
 test("Test that if tag is enabled by default", mocktimeout(function(assert) {
-        
+
         var tpl = new plate.Template("{% if x %}{% endif %}");
         assert.doesNotThrow(function() {
             tpl.render({}, function(err, data) {});
@@ -295,7 +295,7 @@ test("Test that if tag is enabled by default", mocktimeout(function(assert) {
 )
 
 test("Test that =, ==, and != work", mocktimeout(function(assert) {
-        
+
         var pairs = [[~~(Math.random()*10), ~~(10 + Math.random()*10)],
                     [3, 3],
                     ['string', 'string']],
@@ -320,7 +320,7 @@ test("Test that =, ==, and != work", mocktimeout(function(assert) {
 )
 
 test("Test that in and not in work", mocktimeout(function(assert) {
-        
+
         var tpl = new plate.Template("{% for x,y,z in list %}{% if x in y %}y{% endif %}{% if x not in y %}n{% endif %}:{{ z }}\n{% endfor %}"),
             tests = [
                 [[1,2], [1,2,3], 'n'],
@@ -340,7 +340,7 @@ test("Test that in and not in work", mocktimeout(function(assert) {
 )
 
 test("Test that >, <, <=, and >= work", mocktimeout(function(assert) {
-        
+
         var pairs = [[~~(Math.random()*10), ~~(10 + Math.random()*10)],
                     [3, 3],
                     ['string', 'string']],
@@ -367,7 +367,7 @@ test("Test that >, <, <=, and >= work", mocktimeout(function(assert) {
 
 
 test("Test that extends does not trigger a parser error.", mocktimeout(function(assert) {
-        
+
         var tpl = new plate.Template("{% extends whatever %}");
         plate.Template.Meta.registerPlugin('loader', function() {})
         assert.doesNotThrow(function() {
@@ -377,7 +377,7 @@ test("Test that extends does not trigger a parser error.", mocktimeout(function(
 )
 
 test("Test that extending a template produces super great results.", function(assert) {
-        
+
         var base = new plate.Template("hey {% block who %}<b>gary</b>{% endblock %}, how are you?"),
             child = new plate.Template("{% extends base %}{% block who %}{{ block.super }} busey{% endblock %}"),
             ctxt = { base:base };
@@ -391,7 +391,7 @@ test("Test that extending a template produces super great results.", function(as
 )
 
 test("Test that multilevel extending works", function(assert) {
-        
+
         var base = new plate.Template("hey {% block firstname %}{% endblock %} {% block lastname %}{% endblock %}"+
                                         ", {% block greeting %}hi there{% endblock %}"),
             child1 = new plate.Template("{% extends base %}{% block firstname %}gary{% endblock %}"),
@@ -411,7 +411,7 @@ test("Test that multilevel extending works", function(assert) {
 )
 
 test("Test that include does not trigger a parser error", mocktimeout(function(assert) {
-        
+
         var tpl = new plate.Template("{% include something %}");
 
 
@@ -422,7 +422,7 @@ test("Test that include does not trigger a parser error", mocktimeout(function(a
 )
 
 test("Test that include will include the contents of the included template into the includer.", function(assert) {
-        
+
         var random = "random-"+Math.random(),
             include = new plate.Template(random),
             tpl = new plate.Template("{% include tpl %}"),
@@ -468,7 +468,7 @@ test("Test that the loader plugin works with include", function(assert) {
 )
 
 test("Test that comment does not trigger a parser error", mocktimeout(function(assert) {
-        
+
         var tpl = new plate.Template("{% comment %}{% endcomment %}");
         assert.doesNotThrow(function() {
             tpl.getNodeList();
@@ -477,7 +477,7 @@ test("Test that comment does not trigger a parser error", mocktimeout(function(a
 )
 
 test("Test that comment omits all items wrapped inside the comment block.", mocktimeout(function(assert) {
-        
+
         var tpl = new plate.Template("{% comment %}asdf{% endcomment %}");
         tpl.render({}, function(err, data) {
             assert.equal(data, '');
@@ -491,26 +491,26 @@ test("test that now defaults to now N y, J", mocktimeout(function(assert) {
 
       tpl.render({}, function(err, data) {
         assert.equal(data, now)
-      }) 
+      })
 
     })
 )
 
 test("test that now can be configured with another argument", mocktimeout(function(assert) {
-      
+
 
       var tpl = new plate.Template('{% now "jS o\\f F" %}')
         , now = format(new Date, 'jS o\\f F')
 
       tpl.render({}, function(err, data) {
         assert.equal(data, now)
-      }) 
+      })
 
     })
 )
 
 test("test that olde-style loader plugins work", function(assert) {
-  var lib = new library() 
+  var lib = new library()
   lib.register('loader', olde_loader)
 
   var tpl = new plate.Template('{% include "xxx" %}', {plugin_library: lib})
@@ -526,4 +526,4 @@ test("test that olde-style loader plugins work", function(assert) {
       ready(null, new plate.Template('ok'))
     })
   }
-}) 
+})

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -21,7 +21,7 @@ function make_format_equiv(method, for_date, should_equal) {
   return test("test of '"+method+"'", function(assert) {
     var fmt = new utils.DateFormat(for_date)
     assert.equal(''+fmt[method](), ''+should_equal)
-    assert.end()     
+    assert.end()
   })
 }
 
@@ -31,7 +31,7 @@ test("test that the formatter works as expected", function(assert) {
         for(var i = 0; i < str.length; ++i) {
           arr.push(str.charAt(i));
         }
-        return arr 
+        return arr
       }
 
     var format    = strtoarr("aAbcdDEfFgGhHiIjlLmMnNOPrsStTUuwWyYzZ")
@@ -297,7 +297,7 @@ test("test day of year", function(assert) {
   var year = +new Date(new Date().getFullYear(), 0, 1, 0, 0)
     , day = 1000 * 60 * 60 * 24
 
-  for(var i = 0; i < 365; ++i) { 
+  for(var i = 0; i < 365; ++i) {
     assert.equal(utils.date(new Date(year + (day * i) + 1000), 'z'), ''+(i + 1))
   }
 


### PR DESCRIPTION
Variables missing from the context shouldn't result in an early-exit rendering of `''`, since filters may be used to "recover" a value.

A couple examples:
- `{{ a|yesno:"yes,no" }}`; In Django, rendering this with `a` missing from the context would result in `"no"`
- `{{ a|default:"foo" }}`; Likewise, this would result in `"foo"` if the variable was missing

---

I apologize for the somewhat busy diff -- the first patch removes trailing whitespace, because maintaining the trailing whitespace is a pain with the way my editor is set up (it strips trailing whitespace on save), and trailing whitespace is a bad thing anyway.  I'll remove that commit somehow if necessary.
